### PR TITLE
http-client: respect user host header

### DIFF
--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
@@ -72,6 +72,46 @@ public class ApacheHttpRequestFactoryTest {
     }
 
     @Test
+    public void createRespectsUserHostHeader() {
+        String hostOverride = "virtual.host:123";
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+            .uri(URI.create("http://localhost:12345/"))
+            .method(SdkHttpMethod.HEAD)
+            .putHeader("Host", hostOverride)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+            .request(sdkRequest)
+            .build();
+
+        HttpRequestBase result = instance.create(request, requestConfig);
+
+        Header[] hostHeaders = result.getHeaders(HttpHeaders.HOST);
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.length);
+        assertEquals(hostOverride, hostHeaders[0].getValue());
+    }
+
+    @Test
+    public void createRespectsLowercaseUserHostHeader() {
+        String hostOverride = "virtual.host:123";
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+            .uri(URI.create("http://localhost:12345/"))
+            .method(SdkHttpMethod.HEAD)
+            .putHeader("host", hostOverride)
+            .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+            .request(sdkRequest)
+            .build();
+
+        HttpRequestBase result = instance.create(request, requestConfig);
+
+        Header[] hostHeaders = result.getHeaders(HttpHeaders.HOST);
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.length);
+        assertEquals(hostOverride, hostHeaders[0].getValue());
+    }
+
+    @Test
     public void putRequest_withTransferEncodingChunked_isChunkedAndDoesNotIncludeHeader() {
         SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
                                                   .uri(URI.create("http://localhost:12345/"))

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapterTest.java
@@ -106,6 +106,34 @@ public class RequestAdapterTest {
     }
 
     @Test
+    public void adapt_keepsUserHostHeader() {
+        String hostOverride = "virtual.host:123";
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("http://localhost:12345/"))
+                .method(SdkHttpMethod.HEAD)
+                .putHeader("Host", hostOverride)
+                .build();
+        HttpRequest result = h1Adapter.adapt(sdkRequest);
+        List<String> hostHeaders = result.headers()
+                                         .getAll(HttpHeaderNames.HOST.toString());
+        assertThat(hostHeaders).containsExactly(hostOverride);
+    }
+
+    @Test
+    public void adapt_keepsLowercaseUserHostHeader() {
+        String hostOverride = "virtual.host:123";
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("http://localhost:12345/"))
+                .method(SdkHttpMethod.HEAD)
+                .putHeader("host", hostOverride)
+                .build();
+        HttpRequest result = h1Adapter.adapt(sdkRequest);
+        List<String> hostHeaders = result.headers()
+                                         .getAll(HttpHeaderNames.HOST.toString());
+        assertThat(hostHeaders).containsExactly(hostOverride);
+    }
+
+    @Test
     public void adapt_standardHttpsPort_omittedInHeader() {
         SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
                 .uri(URI.create("https://localhost:443/"))


### PR DESCRIPTION
I'm assuming we'll keep/update your PR with all the SDK details

This has the fixes for the http-client implementations (CRT already does things correctly) to respect any user-specified host header. Also fixes a bug where copying of headers during request type conversions was doing case-sensitive comparisons to ignore some headers.

mvn install succeeded
new unit tests pass
requests with our cache use case succeeding when deployed